### PR TITLE
Handle ranges of peer dependencies

### DIFF
--- a/src/installPeerDeps.js
+++ b/src/installPeerDeps.js
@@ -98,7 +98,12 @@ function installPeerDeps({ packageName, version, packageManager, dev, silent }, 
       // Construct packages string with correct versions for install
       let packagesString = `${packageName}`;
       Object.keys(peerDepsVersionMap).forEach((depName) => {
-        packagesString += ` ${depName}@${peerDepsVersionMap[depName]}`;
+        let range = peerDepsVersionMap[depName];
+        // Semver ranges can have a join of comparator sets
+        // e.g. '^3.0.2 || ^4.0.0' or '>=1.2.7 <1.3.0'
+        // We just take the first comparator of the set
+        let comparator = range.split(' ')[0];
+        packagesString += ` ${depName}@${comparator}`;
       });
       // Construct command based on package manager of current project
       const subcommand = packageManager === C.yarn ? 'add' : 'install';

--- a/src/installPeerDeps.js
+++ b/src/installPeerDeps.js
@@ -101,8 +101,9 @@ function installPeerDeps({ packageName, version, packageManager, dev, silent }, 
         let range = peerDepsVersionMap[depName];
         // Semver ranges can have a join of comparator sets
         // e.g. '^3.0.2 || ^4.0.0' or '>=1.2.7 <1.3.0'
-        // We just take the first comparator of the set
-        let comparator = range.split(' ')[0];
+        // We just take the last comparator in the set
+        let rangeSplit = range.split(' ');
+        let comparator = rangeSplit[rangeSplit.length-1];
         packagesString += ` ${depName}@${comparator}`;
       });
       // Construct command based on package manager of current project

--- a/src/installPeerDeps.js
+++ b/src/installPeerDeps.js
@@ -98,13 +98,13 @@ function installPeerDeps({ packageName, version, packageManager, dev, silent }, 
       // Construct packages string with correct versions for install
       let packagesString = `${packageName}`;
       Object.keys(peerDepsVersionMap).forEach((depName) => {
-        let range = peerDepsVersionMap[depName];
+        const range = peerDepsVersionMap[depName];
         // Semver ranges can have a join of comparator sets
         // e.g. '^3.0.2 || ^4.0.0' or '>=1.2.7 <1.3.0'
         // We just take the last comparator in the set
-        let rangeSplit = range.split(' ');
-        let comparator = rangeSplit[rangeSplit.length-1];
-        packagesString += ` ${depName}@${comparator}`;
+        const rangeSplit = range.split(' ');
+        const lastComparator = rangeSplit[rangeSplit.length - 1];
+        packagesString += ` ${depName}@${lastComparator}`;
       });
       // Construct command based on package manager of current project
       const subcommand = packageManager === C.yarn ? 'add' : 'install';


### PR DESCRIPTION
Problem
============

Running

```bash
install-peerdeps eslint-config-airbnb --dev --yarn
```

mentions that it will run:

```bash
install-peerdeps v1.1.2
Installing peerdeps for eslint-config-airbnb@14.1.0.
yarn add eslint-config-airbnb eslint@^3.15.0 eslint-plugin-jsx-a11y@^3.0.2 || ^4.0.0 eslint-plugin-import@^2.2.0 eslint-plugin-react@^6.9.0 --dev
```

`eslint-plugin-jsx-a11y@^3.0.2 || ^4.0.0` is problematic here, and the following error occurs:

```bash
yarn add v0.19.1
[1/4] 🔍  Resolving packages...
error Couldn't find package "^4.0.0" on the "npm" registry.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
ERR The install process exited with error code 1.
```

Solution
============

If a peer dependency is a range like `^3.0.2 || ^4.0.0`, just install the last mentioned comparator. i.e. `^4.0.0`.

This also works for ranges specified as `>=1.2.7 <1.3.0`.