### PR TITLE
feat: Introduce --only-peers flag to install only peerDependencies

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -154,7 +154,7 @@ function installCb(err) {
   if (program.onlyPeers) {
     successMessage = `${successText} The peerDeps of ${packageName} were installed successfully.`;
   }
-  console.log();
+  console.log(successMessage);
   process.exit(0);
 }
 /* eslint-enable */

--- a/src/cli.js
+++ b/src/cli.js
@@ -32,6 +32,7 @@ program
   .version(version)
   .description('Installs the specified package along with correct peerDeps.')
   .option('-d, --dev', 'Install the package as a devDependency')
+  .option('-o, --onlyPeers', 'Install only peerDpenendncies of the package')
   .option('-S, --silent', 'If using npm, don\'t save in package.json')
   .option('-Y, --yarn', 'Install with yarn')
   .usage('<package>[@<version>], default version is \'latest\'')
@@ -108,6 +109,7 @@ const options = {
   packageName,
   version: packageVersion || 'latest',
   dev: program.dev,
+  onlyPeers: program['only-peers'],
   silent: program.silent,
   packageManager,
 };

--- a/src/cli.js
+++ b/src/cli.js
@@ -32,7 +32,7 @@ program
   .version(version)
   .description('Installs the specified package along with correct peerDeps.')
   .option('-d, --dev', 'Install the package as a devDependency')
-  .option('-o, --onlyPeers', 'Install only peerDpenendncies of the package')
+  .option('-o, --only-peers', 'Install only peerDependencies of the package')
   .option('-S, --silent', 'If using npm, don\'t save in package.json')
   .option('-Y, --yarn', 'Install with yarn')
   .usage('<package>[@<version>], default version is \'latest\'')
@@ -109,7 +109,7 @@ const options = {
   packageName,
   version: packageVersion || 'latest',
   dev: program.dev,
-  onlyPeers: program['only-peers'],
+  onlyPeers: program.onlyPeers,
   silent: program.silent,
   packageManager,
 };

--- a/src/cli.js
+++ b/src/cli.js
@@ -149,7 +149,12 @@ function installCb(err) {
     console.log(`${errorText} ${err.message}`);
     process.exit(1);
   }
-  console.log(`${successText} ${packageName} and its peerDeps were installed successfully.`);
+  let successMessage =
+    `${successText} ${packageName} and its peerDeps were installed successfully.`;
+  if (program.onlyPeers) {
+    successMessage = `${successText} The peerDeps of ${packageName} were installed successfully.`;
+  }
+  console.log();
   process.exit(0);
 }
 /* eslint-enable */

--- a/src/installPeerDeps.js
+++ b/src/installPeerDeps.js
@@ -61,7 +61,7 @@ function spawnInstall(command, args) {
   });
 }
 
-function installPeerDeps({ packageName, version, packageManager, dev, silent }, cb) {
+function installPeerDeps({ packageName, version, packageManager, dev, onlyPeers, silent }, cb) {
   // Thanks https://github.com/unpkg/npm-http-server/blob/master/modules/RegistryUtils.js
   // for scoped modules help
   let encodedPackageName;
@@ -96,7 +96,7 @@ function installPeerDeps({ packageName, version, packageManager, dev, silent }, 
       }
 
       // Construct packages string with correct versions for install
-      let packagesString = `${packageName}`;
+      let packagesString = onlyPeers ? '' : `${packageName}`;
       Object.keys(peerDepsVersionMap).forEach((depName) => {
         const range = peerDepsVersionMap[depName];
         // Semver ranges can have a join of comparator sets

--- a/src/installPeerDeps.js
+++ b/src/installPeerDeps.js
@@ -141,6 +141,12 @@ function installPeerDeps({ packageName, version, packageManager, dev, onlyPeers,
         args = args.concat('--save');
       }
 
+      // Remove empty args
+      // There's a bug with Yarn 1.0 in which an empty arg
+      // causes the install process to fail with a "malformed
+      // response from the registry" error
+      args = args.filter(a => a !== '');
+
       //  Show user the command that's running
       console.log(`Installing peerdeps for ${packageName}@${version}.`);
       console.log(`${packageManager} ${args.join(' ')}\n`);

--- a/src/installPeerDeps.js
+++ b/src/installPeerDeps.js
@@ -96,6 +96,7 @@ function installPeerDeps({ packageName, version, packageManager, dev, onlyPeers,
       }
 
       // Construct packages string with correct versions for install
+      // If onlyPeers option is true, don't install the package itself, only its peers.
       let packagesString = onlyPeers ? '' : `${packageName}`;
       Object.keys(peerDepsVersionMap).forEach((depName) => {
         const range = peerDepsVersionMap[depName];


### PR DESCRIPTION
By default, the package will also be installed. With `--only-peers` only `peerDependencies` of this
package will be installed.

Closes #9