### PR TITLE
Add option to pass Auth header

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ To install from a custom registry, use the `--registry` option:
 
 `install-peerdeps my-custom-package --registry https://registry.mycompany.com`.
 
+### Installing a Private Package
+To install a private npm package (either from npm or from a registry that uses an authorization header), use the auth option:
+
+`install-peerdeps my-private-package --auth your-npm-auth-token`
+
 ### Proxies
 To use this tool with a proxy, set the `HTTPS_PROXY` environment variable (if you're using a custom registry and it is only accessible over HTTP, though, set the `HTTP_PROXY` environment variable).
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest",
     "lint": "eslint src/ --fix",
-    "build": "babel src --out-dir lib --ignore **/*.test.js",
+    "build": "babel src --out-dir lib --ignore *.test.js",
     "prepare": "npm run build"
   },
   "preferGlobal": true,

--- a/src/cli.js
+++ b/src/cli.js
@@ -55,7 +55,7 @@ program
   )
   .option(
     "-a, --auth <token>",
-    "Provide auth token or basic auth for private packages."
+    "Provide an NPM authToken for private packages."
   )
   .usage("<package>[@<version>], default version is 'latest'")
   .parse(process.argv);

--- a/src/cli.js
+++ b/src/cli.js
@@ -53,6 +53,10 @@ program
     "--dry-run",
     "Do not install packages, but show the install command that will be run"
   )
+  .option(
+    "-a, --auth <token>",
+    "Provide auth token or basic auth for private packages."
+  )
   .usage("<package>[@<version>], default version is 'latest'")
   .parse(process.argv);
 
@@ -132,7 +136,8 @@ const options = {
   onlyPeers: program.onlyPeers,
   silent: program.silent,
   packageManager,
-  dryRun: program.dryRun
+  dryRun: program.dryRun,
+  auth: program.auth
 };
 
 // Disabled this rule so we can hoist the callback
@@ -179,13 +184,13 @@ function installCb(err) {
     console.log(`${C.errorText} ${err.message}`);
     process.exit(1);
   }
-  let successMessage = `${C.successText} ${
-    packageName
-  } and its peerDeps were installed successfully.`;
+  let successMessage = `${
+    C.successText
+  } ${packageName} and its peerDeps were installed successfully.`;
   if (program.onlyPeers) {
-    successMessage = `${C.successText} The peerDeps of ${
-      packageName
-    } were installed successfully.`;
+    successMessage = `${
+      C.successText
+    } The peerDeps of ${packageName} were installed successfully.`;
   }
   console.log(successMessage);
   process.exit(0);


### PR DESCRIPTION
I was unable to add a private package because there was not a way to pass the auth token to the request, so I updated the cli to take an auth option and then updated the request function to send an authorization header.

There are also some strange formatting changes from the linter... it's breaking the lines in different places.