### PR TITLE
Feature proxy support

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-polyfill": "^6.26.0",
     "cli-color": "^1.2.0",
     "commander": "^2.11.0",
+    "https-proxy-agent": "^2.2.1",
     "promptly": "^2.1.0",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",

--- a/src/cli.js
+++ b/src/cli.js
@@ -59,6 +59,10 @@ program
     "-a, --auth <token>",
     "Provide an NPM authToken for private packages."
   )
+  .option(
+    "-p, --proxy <http_proxy>",
+    "Enable http proxy to connect to the registry"
+  )
   .usage("<package>[@<version>], default version is 'latest'")
   .parse(process.argv);
 
@@ -133,7 +137,8 @@ const options = {
   dryRun: program.dryRun,
   auth: program.auth,
   // Args after -- will be passed through
-  extraArgs: program.args.slice(1)
+  extraArgs: program.args.slice(1),
+  proxy: program.proxy
 };
 
 // Disabled this rule so we can hoist the callback

--- a/src/install-peerdeps.js
+++ b/src/install-peerdeps.js
@@ -200,6 +200,11 @@ function installPeerDeps(
       }
 
       let args = [];
+      // If any proxy setting were passed then include the http proxy agent.
+      var requestProxy = process.env.HTTP_PROXY || process.env.http_proxy || `${proxy}`;
+      if (requestProxy !== 'undefined') {
+        args = args.concat("--proxy " + requestProxy);
+      }
       // I know I can push it, but I'll just
       // keep concatenating for consistency
       args = args.concat(subcommand);


### PR DESCRIPTION
Instead of doing:
```
HTTP_PROXY=http://167.99.224.142:8080 install-peerdeps eslint-config-airbnb-base --dev
```
You can now do:
```
install-peerdeps -p http://167.99.224.142:8080 eslint-config-airbnb-base --dev
```
But you can still use
```
HTTP_PROXY=http://167.99.224.142:8080 install-peerdeps eslint-config-airbnb-base --dev
```