### PR TITLE
Added support for --global flag

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -44,6 +44,7 @@ program
   .version(version)
   .description("Installs the specified package along with correct peerDeps.")
   .option("-d, --dev", "Install the package as a devDependency")
+  .option("-g, --global", "Install the package globally")
   .option("-o, --only-peers", "Install only peerDependencies of the package")
   .option("-S, --silent", "If using npm, don't save in package.json")
   .option("-Y, --yarn", "Install with Yarn")
@@ -121,6 +122,14 @@ if (program.dev && program.silent) {
   process.exit(9);
 }
 
+// Dev option can't be used with global,
+// since --dev means it should be saved
+// as a devDependency (locally)
+if (program.dev && program.silent) {
+  console.log(`${C.errorText} Option --dev cannot be used with --global.`);
+  process.exit(9);
+}
+
 if (program.registry) {
   const { registry } = program;
   // Check if last character in registry is a trailing slash
@@ -139,6 +148,7 @@ const options = {
   // If registry is undefined, default to the official NPM registry
   registry: program.registry || "https://registry.npmjs.com",
   dev: program.dev,
+  global: program.global,
   onlyPeers: program.onlyPeers,
   silent: program.silent,
   packageManager,

--- a/src/install-peerdeps.js
+++ b/src/install-peerdeps.js
@@ -108,6 +108,7 @@ function installPeerDeps(
     packageManager,
     registry,
     dev,
+    global,
     onlyPeers,
     silent,
     dryRun,
@@ -173,6 +174,10 @@ function installPeerDeps(
         }
       });
       // Construct command based on package manager of current project
+      let globalFlag = packageManager === C.yarn ? "global" : "--global";
+      if (!global) {
+        globalFlag = "";
+      }
       const subcommand = packageManager === C.yarn ? "add" : "install";
       let devFlag = packageManager === C.yarn ? "--dev" : "--save-dev";
       if (!dev) {
@@ -189,6 +194,8 @@ function installPeerDeps(
       let args = [];
       // I know I can push it, but I'll just
       // keep concatenating for consistency
+      // global must preceed add in yarn; npm doesn't care
+      args = args.concat(globalFlag);
       args = args.concat(subcommand);
       // See issue #33 - issue with "-0"
       function fixPackageName(packageName) {
@@ -208,9 +215,9 @@ function installPeerDeps(
         args = args.concat(devFlag);
       }
       // If we're using NPM, and there's no dev flag,
-      // and it's not a silent install make sure to save
-      // deps in package.json under "dependencies"
-      if (devFlag === "" && packageManager === C.npm && !silent) {
+      // and it's not a silent install and it's not a global install
+      // make sure to save deps in package.json under "dependencies"
+      if (devFlag === "" && packageManager === C.npm && !silent && !global) {
         args = args.concat("--save");
       }
       // If we are using NPM, and there's no dev flag,


### PR DESCRIPTION
Also made a fix to getCliInstallCommand to capture and parse stdout in a platform-independent manner.

Feel free to modify as you see fit.  No real need to keep the `const cmd = command.toString();` lines.  I had written those when `command` could have been a `Buffer` and was writing them using `console.log` to troubleshoot.

Found two things:

1) the very last line of stdout was actually a blank line following the command

2) the type of `data` in `stdout.on('data', data => ...` can be Buffer

3) `stdout.on` is not guaranteed to be called for any particular amount of output from the external process so I had it capture to an array (as it was already doing) but then joining with blank (causing a .toString() on each Buffer), splitting on either *nix or Windows line endings, and finding the last non-whitespace-only line.

All tests now passing on Windows 10 with node v10.8.0.