### PR TITLE
Support both `-D` & `-d` flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "tape": "tape --require=babel-polyfill",
     "pretests-only": "npm run build:test",
-    "tests-only": "npm run tape test/*.test.js",
+    "tests-only": "npm run tape test/*.test.js | tap-spec",
     "lint": "eslint src/ --fix",
     "clean": "rimraf lib",
     "prebuild": "npm run clean",
@@ -65,6 +65,7 @@
     "jest": "^21.2.1",
     "prettier": "^1.8.1",
     "rimraf": "^2.6.2",
+    "tap-spec": "^5.0.0",
     "tape": "^4.9.1"
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -23,19 +23,13 @@ const { name, version } = pkg;
  */
 function printPackageFormatError() {
   console.log(
-    `${
-      C.errorText
-    } Please specify the package to install with peerDeps in the form of \`package\` or \`package@n.n.n\``
+    `${C.errorText} Please specify the package to install with peerDeps in the form of \`package\` or \`package@n.n.n\``
   );
   console.log(
-    `${
-      C.errorText
-    } At this time you must provide the full semver version of the package.`
+    `${C.errorText} At this time you must provide the full semver version of the package.`
   );
   console.log(
-    `${
-      C.errorText
-    } Alternatively, omit it to automatically install the latest version of the package.`
+    `${C.errorText} Alternatively, omit it to automatically install the latest version of the package.`
   );
 }
 
@@ -43,6 +37,7 @@ function printPackageFormatError() {
 program
   .version(version)
   .description("Installs the specified package along with correct peerDeps.")
+  .option("-D, --dev")
   .option("-d, --dev", "Install the package as a devDependency")
   .option("-g, --global", "Install the package globally")
   .option("-o, --only-peers", "Install only peerDependencies of the package")
@@ -88,9 +83,7 @@ if (program.args.length === 0) {
 // Make sure we're installing no more than one package
 if (program.args.length > 1) {
   console.log(
-    `${
-      C.errorText
-    } Too many arguments. Please specify ONE package at a time to install with peerDeps. Alternatively, pass extra arguments with --extra-args "<extra_args>".`
+    `${C.errorText} Too many arguments. Please specify ONE package at a time to install with peerDeps. Alternatively, pass extra arguments with --extra-args "<extra_args>".`
   );
   // An exit code of "9" indicates an invalid argument
   // See https://nodejs.org/api/process.html#process_exit_codes
@@ -214,9 +207,7 @@ function installCb(err) {
   let successMessage = `${C.successText} ${packageName}
   and its peerDeps were installed successfully.`;
   if (program.onlyPeers) {
-    successMessage = `${
-      C.successText
-    } The peerDeps of ${packageName} were installed successfully.`;
+    successMessage = `${C.successText} The peerDeps of ${packageName} were installed successfully.`;
   }
   console.log(successMessage);
   process.exit(0);

--- a/src/cli.test.js
+++ b/src/cli.test.js
@@ -90,6 +90,20 @@ test("only installs peerDependencies when `--only-peers` is specified", t => {
   );
 });
 
+test("adds explicit `--save-dev` flag when using `-D, -d, --dev` with NPM", t => {
+  const flags = ["-D", "-d", "--dev"];
+  Promise.all(
+    flags.map(flag => getCliInstallCommand(["eslint-config-airbnb", flag]))
+  )
+    .then(commands => {
+      commands.forEach((cmd, i) =>
+        t.equal(/\s--save-dev$/.test(cmd), true, `flag: \`${flags[i]}\``)
+      );
+      t.end();
+    })
+    .catch(t.fail);
+});
+
 test("places `global` as first arg following `yarn` when using yarn and `--global` is specified", t => {
   getCliInstallCommand(["eslint-config-airbnb", "--global", "-Y"]).then(
     command => {


### PR DESCRIPTION
Aligning flags with `npm` ones due to `-D, --save-dev` being used for dev installations (https://docs.npmjs.com/cli/install).