### PR TITLE
Check in node_modules for the package, if installing with --only-peers

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -23,19 +23,13 @@ const { name, version } = pkg;
  */
 function printPackageFormatError() {
   console.log(
-    `${
-      C.errorText
-    } Please specify the package to install with peerDeps in the form of \`package\` or \`package@n.n.n\``
+    `${C.errorText} Please specify the package to install with peerDeps in the form of \`package\` or \`package@n.n.n\``
   );
   console.log(
-    `${
-      C.errorText
-    } At this time you must provide the full semver version of the package.`
+    `${C.errorText} At this time you must provide the full semver version of the package.`
   );
   console.log(
-    `${
-      C.errorText
-    } Alternatively, omit it to automatically install the latest version of the package.`
+    `${C.errorText} Alternatively, omit it to automatically install the latest version of the package.`
   );
 }
 
@@ -79,18 +73,16 @@ if (program.args.length === 0) {
   console.log(
     `${C.errorText} Please specify a package to install with peerDeps.`
   );
-  program.help();
   // An exit code of "9" indicates an invalid argument
   // See https://nodejs.org/api/process.html#process_exit_codes
-  process.exit(9);
+  process.exitCode = 9;
+  program.help();
 }
 
 // Make sure we're installing no more than one package
 if (program.args.length > 1) {
   console.log(
-    `${
-      C.errorText
-    } Too many arguments. Please specify ONE package at a time to install with peerDeps. Alternatively, pass extra arguments with --extra-args "<extra_args>".`
+    `${C.errorText} Too many arguments. Please specify ONE package at a time to install with peerDeps. Alternatively, pass extra arguments with --extra-args "<extra_args>".`
   );
   // An exit code of "9" indicates an invalid argument
   // See https://nodejs.org/api/process.html#process_exit_codes
@@ -214,9 +206,7 @@ function installCb(err) {
   let successMessage = `${C.successText} ${packageName}
   and its peerDeps were installed successfully.`;
   if (program.onlyPeers) {
-    successMessage = `${
-      C.successText
-    } The peerDeps of ${packageName} were installed successfully.`;
+    successMessage = `${C.successText} The peerDeps of ${packageName} were installed successfully.`;
   }
   console.log(successMessage);
   process.exit(0);

--- a/src/cli.test.js
+++ b/src/cli.test.js
@@ -8,14 +8,15 @@ import test from "tape";
  * @param {string[]} extraArgs - arguments to be passed to the CLI
  * @returns {ChildProcess} - an EventEmitter that represents the spawned child process
  */
-function spawnCli(extraArgs, cwd = "sandbox") {
-  return spawn(
-    "node",
-    ["--require", "babel-register", path.join(__dirname, "cli.js")].concat(
-      extraArgs
-    ),
-    { cwd: path.join(__dirname, "..", "fixtures", cwd) }
-  );
+function spawnCli(extraArgs = [], cwd = "sandbox") {
+  const args = [
+    "--require",
+    "babel-register",
+    path.join(__dirname, "cli.js")
+  ].concat(extraArgs);
+  return spawn("node", args, {
+    cwd: path.join(__dirname, "..", "fixtures", cwd)
+  });
 }
 
 /**
@@ -83,7 +84,7 @@ test("only installs peerDependencies when `--only-peers` is specified", t => {
   getCliInstallCommand(["eslint-config-airbnb", "--only-peers"]).then(
     command => {
       const cmd = command.toString();
-      t.equal(/\beslint-config-airbnb\b/.test(cmd), false);
+      t.equal(/\beslint-config-airbnb\b/.test(cmd), false, cmd);
       t.end();
     },
     t.fail
@@ -94,7 +95,7 @@ test("places `global` as first arg following `yarn` when using yarn and `--globa
   getCliInstallCommand(["eslint-config-airbnb", "--global", "-Y"]).then(
     command => {
       const cmd = command.toString();
-      t.equal(/\byarn global\b/.test(cmd), true);
+      t.equal(/\byarn global\b/.test(cmd), true, cmd);
       t.end();
     },
     t.fail
@@ -104,7 +105,7 @@ test("places `global` as first arg following `yarn` when using yarn and `--globa
 test("adds explicit `--global` flag when using `--global` with NPM", t => {
   getCliInstallCommand(["eslint-config-airbnb", "--global"]).then(command => {
     const cmd = command.toString();
-    t.equal(/\bnpm\s--global\b/.test(cmd), true);
+    t.equal(/\bnpm\s--global\b/.test(cmd), true, cmd);
     t.end();
   }, t.fail);
 });
@@ -112,7 +113,7 @@ test("adds explicit `--global` flag when using `--global` with NPM", t => {
 test("does not add `--save` when using `--global` with NPM", t => {
   getCliInstallCommand(["eslint-config-airbnb", "--global"]).then(command => {
     const cmd = command.toString();
-    t.equal(/\s--save\b/.test(cmd), false);
+    t.equal(/\s--save\b/.test(cmd), false, cmd);
     t.end();
   }, t.fail);
 });
@@ -120,7 +121,7 @@ test("does not add `--save` when using `--global` with NPM", t => {
 test("adds an explicit `--no-save` when using `--silent` with NPM", t => {
   getCliInstallCommand(["eslint-config-airbnb", "--silent"]).then(command => {
     const cmd = command.toString();
-    t.equal(/\s--no-save\b/.test(cmd), true);
+    t.equal(/\s--no-save\b/.test(cmd), true, cmd);
     t.end();
   }, t.fail);
 });

--- a/src/cli.test.js
+++ b/src/cli.test.js
@@ -8,15 +8,14 @@ import test from "tape";
  * @param {string[]} extraArgs - arguments to be passed to the CLI
  * @returns {ChildProcess} - an EventEmitter that represents the spawned child process
  */
-function spawnCli(extraArgs = [], cwd = "sandbox") {
-  const args = [
-    "--require",
-    "babel-register",
-    path.join(__dirname, "cli.js")
-  ].concat(extraArgs);
-  return spawn("node", args, {
-    cwd: path.join(__dirname, "..", "fixtures", cwd)
-  });
+function spawnCli(extraArgs, cwd = "sandbox") {
+  return spawn(
+    "node",
+    ["--require", "babel-register", path.join(__dirname, "cli.js")].concat(
+      extraArgs
+    ),
+    { cwd: path.join(__dirname, "..", "fixtures", cwd) }
+  );
 }
 
 /**
@@ -84,7 +83,7 @@ test("only installs peerDependencies when `--only-peers` is specified", t => {
   getCliInstallCommand(["eslint-config-airbnb", "--only-peers"]).then(
     command => {
       const cmd = command.toString();
-      t.equal(/\beslint-config-airbnb\b/.test(cmd), false, cmd);
+      t.equal(/\beslint-config-airbnb\b/.test(cmd), false);
       t.end();
     },
     t.fail
@@ -95,7 +94,7 @@ test("places `global` as first arg following `yarn` when using yarn and `--globa
   getCliInstallCommand(["eslint-config-airbnb", "--global", "-Y"]).then(
     command => {
       const cmd = command.toString();
-      t.equal(/\byarn global\b/.test(cmd), true, cmd);
+      t.equal(/\byarn global\b/.test(cmd), true);
       t.end();
     },
     t.fail
@@ -105,7 +104,7 @@ test("places `global` as first arg following `yarn` when using yarn and `--globa
 test("adds explicit `--global` flag when using `--global` with NPM", t => {
   getCliInstallCommand(["eslint-config-airbnb", "--global"]).then(command => {
     const cmd = command.toString();
-    t.equal(/\bnpm\s--global\b/.test(cmd), true, cmd);
+    t.equal(/\bnpm\s--global\b/.test(cmd), true);
     t.end();
   }, t.fail);
 });
@@ -113,7 +112,7 @@ test("adds explicit `--global` flag when using `--global` with NPM", t => {
 test("does not add `--save` when using `--global` with NPM", t => {
   getCliInstallCommand(["eslint-config-airbnb", "--global"]).then(command => {
     const cmd = command.toString();
-    t.equal(/\s--save\b/.test(cmd), false, cmd);
+    t.equal(/\s--save\b/.test(cmd), false);
     t.end();
   }, t.fail);
 });
@@ -121,7 +120,7 @@ test("does not add `--save` when using `--global` with NPM", t => {
 test("adds an explicit `--no-save` when using `--silent` with NPM", t => {
   getCliInstallCommand(["eslint-config-airbnb", "--silent"]).then(command => {
     const cmd = command.toString();
-    t.equal(/\s--no-save\b/.test(cmd), true, cmd);
+    t.equal(/\s--no-save\b/.test(cmd), true);
     t.end();
   }, t.fail);
 });

--- a/src/install-peerdeps.js
+++ b/src/install-peerdeps.js
@@ -102,7 +102,7 @@ function spawnInstall(command, args) {
 /**
  * Gets the contents of the package.json for a package at a specific version
  * @param {Object} requestInfo - information needed to make the request for the data
- * @param {string} requestInfo.encodedPackageName - the urlencoded name of the package
+ * @param {string} requestInfo.packageName - the name of the package
  * @param {string} requestInfo.registry - the URI of the registry on which the package is hosted
  * @param {Boolean} onlyPeers - true if only the peers have been requested to be installed. In this case, check for the package to already have been installed.
  * @param {string} version - the version (or version tag) to attempt to install. Ignored if an installed version of the package is found in node_modules.
@@ -137,12 +137,6 @@ function getPackageJson(
       versionToInstall = data["dist-tags"][version];
     }
 
-    if (typeof peerDepsVersionMap === "undefined") {
-      throw new Error(
-        "The package you are trying to install has no peer " +
-          "dependencies. Use yarn or npm to install it manually."
-      );
-    }
     return data.versions[versionToInstall];
   });
 }
@@ -184,6 +178,12 @@ function installPeerDeps(
     .then(data => {
       // Get peer dependencies for max satisfying version
       const peerDepsVersionMap = data.peerDependencies;
+      if (typeof peerDepsVersionMap === "undefined") {
+        throw new Error(
+          "The package you are trying to install has no peer " +
+            "dependencies. Use yarn or npm to install it manually."
+        );
+      }
 
       // Construct packages string with correct versions for install
       // If onlyPeers option is true, don't install the package itself,

--- a/src/install-peerdeps.test.js
+++ b/src/install-peerdeps.test.js
@@ -1,12 +1,11 @@
 import test from "tape";
-import { getPackageData, encodePackageName } from "./install-peerdeps";
+import { getPackageData } from "./install-peerdeps";
 
 test("gets the package data from the registry correctly", t => {
   // Only one async operation will run
   t.plan(1);
-  const encodedPackageName = encodePackageName("eslint-config-airbnb");
   getPackageData({
-    encodedPackageName,
+    packageName: "eslint-config-airbnb",
     registry: "https://registry.npmjs.com"
   }).then(packageData => {
     t.equal(packageData.name, "eslint-config-airbnb");


### PR DESCRIPTION
This allows install-peerdeps to work for packages that aren't available in a registry (e.g. installed from git, or with `yarn link`).