### PR TITLE
Fix installation not starting after package manager confirmation.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -173,25 +173,28 @@ const options = {
 // Disabled this rule so we can hoist the callback
 /* eslint-disable no-use-before-define */
 
+
 // Check if the user has Yarn but didn't specify the Yarn option
 // However, don't show prompt if user wants to install silently
 if (hasYarn() && packageManager !== C.yarn && !program.silent) {
   // If they do, ask if they want to use Yarn
   confirm(
-    "It seems as if you are using Yarn. Would you like to use Yarn for the installation? (y/n)",
-    (err, value) => {
-      if (err) {
-        console.log(`${C.errorText} ${err.message}`);
-        process.exit(1);
-      }
+    "It seems as if you are using Yarn. Would you like to use Yarn for the installation? (y/n)"
+  )
+    .then(value => {
       // Value is true or false; if true, they want to use Yarn
       if (value) {
         packageManager = C.yarn;
       }
       // Now install, but with the new packageManager
       installPeerDeps({ ...options, packageManager }, installCb);
-    }
-  );
+    })
+    .catch(err => {
+      if (err) {
+        console.log(`${C.errorText} ${err.message}`);
+        process.exit(1);
+      }
+    });
 } else {
   // If they don't have Yarn or they've already
   // opted to use Yarn, go ahead and install

--- a/src/cli.js
+++ b/src/cli.js
@@ -173,7 +173,6 @@ const options = {
 // Disabled this rule so we can hoist the callback
 /* eslint-disable no-use-before-define */
 
-
 // Check if the user has Yarn but didn't specify the Yarn option
 // However, don't show prompt if user wants to install silently
 if (hasYarn() && packageManager !== C.yarn && !program.silent) {


### PR DESCRIPTION
**Expected Behaviour**
After receiving confirmation from the user that they would like to use yarn as their package manager, the script proceeds to install peer dependencies with yarn.

**Current Behaviour**
After receiving confirmation to use yarn, the script exits without installation.

**Fix**
Updated the implementation of promptly's confirm function to use a promise instead of a callback.