### PR TITLE
Add a feature flag to split remote registry from onlyPeers flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Options:
   -S, --silent                     If using npm, don't save in package.json
   -Y, --yarn                       Install with Yarn
   -P, --pnpm                       Install with pnpm
+  -n, --no-registry                Do not use a remote registry to find dependencies list
   -r, --registry <uri>             Install from custom registry (defaults to NPM registry)
   --dry-run                        Do not install packages, but show the install command that will be run
   -a, --auth <token>               Provide an NPM authToken for private packages.

--- a/src/cli.js
+++ b/src/cli.js
@@ -45,6 +45,10 @@ program
   .option("-Y, --yarn", "Install with Yarn")
   .option("-P, --pnpm", "Install with pnpm")
   .option(
+    "-n, --no-registry",
+    "Use local node_modules instead of a remote registry to get the list of peerDependencies"
+  )
+  .option(
     "-r, --registry <uri>",
     "Install from custom registry (defaults to NPM registry)"
   )
@@ -156,6 +160,7 @@ const options = {
   packageName,
   // If packageVersion is undefined, default to "latest"
   version: packageVersion || "latest",
+  noRegistry: program.noRegistry,
   // If registry is undefined, default to the official NPM registry
   registry: program.registry || "https://registry.npmjs.com",
   dev: devMode,

--- a/src/install-peerdeps.js
+++ b/src/install-peerdeps.js
@@ -180,6 +180,7 @@ const getPackageString = ({ name, version }) => {
  * @param {string} options.packageName - the name of the package for which to install peer dependencies
  * @param {string} options.version - the version of the package
  * @param {string} options.packageManager - the package manager to use (Yarn or npm)
+ * @param {string} options.noRegistry - Disable going to a remote registry to find a list of peers. Use local node_modules instead
  * @param {string} options.registry - the URI of the registry to install from
  * @param {string} options.dev - whether to install the dependencies as devDependencies
  * @param {boolean} options.onlyPeers - whether to install the package itself or only its peers
@@ -193,6 +194,7 @@ function installPeerDeps(
     packageName,
     version,
     packageManager,
+    noRegistry,
     registry,
     dev,
     global,
@@ -205,7 +207,7 @@ function installPeerDeps(
   },
   cb
 ) {
-  getPackageJson({ packageName, noRegistry:onlyPeers, registry, auth, proxy, version })
+  getPackageJson({ packageName, noRegistry, registry, auth, proxy, version })
     // Catch before .then because the .then is so long
     .catch(err => cb(err))
     .then(data => {

--- a/src/install-peerdeps.js
+++ b/src/install-peerdeps.js
@@ -106,17 +106,20 @@ function spawnInstall(command, args) {
  * Gets the contents of the package.json for a package at a specific version
  * @param {Object} requestInfo - information needed to make the request for the data
  * @param {string} requestInfo.packageName - the name of the package
+ * @param {Boolean} requestInfo.noRegistry - Gets the package dependencies list from the local node_modules instead of remote registry
  * @param {string} requestInfo.registry - the URI of the registry on which the package is hosted
- * @param {Boolean} onlyPeers - true if only the peers have been requested to be installed. In this case, check for the package to already have been installed.
- * @param {string} version - the version (or version tag) to attempt to install. Ignored if an installed version of the package is found in node_modules.
+ * @param {string} requestInfo.version - the version (or version tag) to attempt to install. Ignored if an installed version of the package is found in node_modules.
  * @returns {Promise<Object>} - a Promise which resolves to the JSON response from the registry
  */
-function getPackageJson(
-  { packageName, registry, auth, proxy },
-  onlyPeers,
+function getPackageJson({
+  packageName,
+  noRegistry,
+  registry,
+  auth,
+  proxy,
   version
-) {
-  if (onlyPeers) {
+}) {
+  if (noRegistry) {
     if (fs.existsSync(`node_modules/${packageName}`)) {
       return Promise.resolve(
         JSON.parse(
@@ -202,7 +205,7 @@ function installPeerDeps(
   },
   cb
 ) {
-  getPackageJson({ packageName, registry, auth, proxy }, onlyPeers, version)
+  getPackageJson({ packageName, noRegistry:onlyPeers, registry, auth, proxy, version })
     // Catch before .then because the .then is so long
     .catch(err => cb(err))
     .then(data => {


### PR DESCRIPTION
In response to #73 

If this enhancement is added, then I believe the need for this app to support proxies goes away entirely, as a developer can use their normal `.npmrc` setup instead. This PR doesn't remove any of the auth and proxy features. Just introduces a configuration that lets us avoid them for certain use cases.

`--only-peers` was doing two different things which complicated the need
for proxy settings. Not only was it flagging whether to install the main
package with the peers, it was also toggling whether the peerDeps list
was being generated from a local node_modules vs a remote registry.

By splitting this into two distinct feature flags, we make behavior clearer,
and future case of delegating proxy settings to NPM or Yarn instead
of handling those in the utility.

BREAKING_CHANGE: `--only-peers` now searches for peerDeps via the registry
unless `--no-registry` is also specified

* was: `install-peerdeps <package> --only-peers`
* now: `install-peerdeps <package> --only-peers --no-registry`