### PR TITLE
use package manager to get info

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Options:
   -S, --silent                     If using npm, don't save in package.json
   -Y, --yarn                       Install with Yarn
   -P, --pnpm                       Install with pnpm
+  -n, --no-registry                Do not use a remote registry to find dependencies list
   -r, --registry <uri>             Install from custom registry (defaults to NPM registry)
   --dry-run                        Do not install packages, but show the install command that will be run
   -a, --auth <token>               Provide an NPM authToken for private packages.

--- a/README.md
+++ b/README.md
@@ -63,10 +63,7 @@ Options:
   -Y, --yarn                       Install with Yarn
   -P, --pnpm                       Install with pnpm
   -n, --no-registry                Do not use a remote registry to find dependencies list
-  -r, --registry <uri>             Install from custom registry (defaults to NPM registry)
   --dry-run                        Do not install packages, but show the install command that will be run
-  -a, --auth <token>               Provide an NPM authToken for private packages.
-  -p, --proxy <http_proxy>         Enable http proxy to connect to the registry
   -x, --extra-args "<extra_args>"  Extra arguments to pass through to NPM or Yarn
   -h, --help                       output usage information
 ```
@@ -79,7 +76,7 @@ Only core Yarn and NPM arguments relating to package installation are officially
 
 Here's how you'd use `--extra-args` to pass a custom NPM config option (in this case, disabling `strict-ssl` when accessing a custom registry over HTTPS):
 
-`install-peerdeps <package> -p http://proxy:8080 --extra-args "--strict-ssl false"`
+`install-peerdeps <package> --extra-args "--strict-ssl false"`
 
 ## Examples
 
@@ -117,32 +114,6 @@ yarn add @angular/core rxjs@^5.0.1 zone.js@^0.7.2
 yarn add v0.18.1
 ...
 ```
-
-### Installing from a Custom Registry
-
-To install from a custom registry, use the `--registry` option:
-
-`install-peerdeps my-custom-package --registry https://registry.mycompany.com`.
-
-### Installing a Private Package
-
-To install a private npm package (either from npm or from a registry that uses an authorization header), use the auth option:
-
-`install-peerdeps my-private-package --auth your-npm-auth-token`
-
-### Proxies
-
-To use this tool with a proxy, set the `HTTPS_PROXY` environment variable (if you're using a custom registry and it is only accessible over HTTP, though, set the `HTTP_PROXY` environment variable).
-
-Under the hood, this package uses the `request` module to get package information from the registry and it spawns an NPM or Yarn child process for the actual installation.
-
-`request` respects the `HTTP_PROXY` and `HTTPS_PROXY` environment variables, and `spawn` passes environment variables to the child process, so if you have the `PROXY` environment variables correctly set, everything should work. Nonetheless, proxy support is a new addition to this tool (added in v1.4.0), so please leave an issue if you have any problems.
-
-`HTTPS_PROXY=https://proxy.mycompany.com/ install-peerdeps my-company-package`
-
-Alternatively, you may use the `--proxy` flag like so:
-
-`install-peerdeps my-company-package --proxy https://proxy.mycompany.com/`
 
 ## Contributing
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -45,6 +45,10 @@ program
   .option("-Y, --yarn", "Install with Yarn")
   .option("-P, --pnpm", "Install with pnpm")
   .option(
+    "-n, --no-registry",
+    "Use local node_modules instead of a remote registry to get the list of peerDependencies"
+  )
+  .option(
     "-r, --registry <uri>",
     "Install from custom registry (defaults to NPM registry)"
   )
@@ -156,6 +160,7 @@ const options = {
   packageName,
   // If packageVersion is undefined, default to "latest"
   version: packageVersion || "latest",
+  noRegistry: program.noRegistry,
   // If registry is undefined, default to the official NPM registry
   // See: https://docs.npmjs.com/using-npm/registry.html
   registry: program.registry || "https://registry.npmjs.org",

--- a/src/cli.js
+++ b/src/cli.js
@@ -49,20 +49,8 @@ program
     "Use local node_modules instead of a remote registry to get the list of peerDependencies"
   )
   .option(
-    "-r, --registry <uri>",
-    "Install from custom registry (defaults to NPM registry)"
-  )
-  .option(
     "--dry-run",
     "Do not install packages, but show the install command that will be run"
-  )
-  .option(
-    "-a, --auth <token>",
-    "Provide an NPM authToken for private packages."
-  )
-  .option(
-    "-p, --proxy <http_proxy>",
-    "Enable http proxy to connect to the registry"
   )
   .option(
     '-x, --extra-args "<extra_args>"',
@@ -145,15 +133,6 @@ if (devMode && program.silent) {
   process.exit(9);
 }
 
-if (program.registry) {
-  const { registry } = program;
-  // Check if last character in registry is a trailing slash
-  if (registry.substr(-1) === "/") {
-    // If the last character is a trailing slash, remove it
-    program.registry = registry.slice(0, -1);
-  }
-}
-
 // Define options object to pass to
 // the installPeerDeps function
 const options = {
@@ -161,9 +140,6 @@ const options = {
   // If packageVersion is undefined, default to "latest"
   version: packageVersion || "latest",
   noRegistry: program.noRegistry,
-  // If registry is undefined, default to the official NPM registry
-  // See: https://docs.npmjs.com/using-npm/registry.html
-  registry: program.registry || "https://registry.npmjs.org",
   dev: devMode,
   global: program.global,
   onlyPeers: program.onlyPeers,
@@ -172,8 +148,7 @@ const options = {
   dryRun: program.dryRun,
   auth: program.auth,
   // Args after -- will be passed through
-  extraArgs: program.extraArgs || "",
-  proxy: program.proxy
+  extraArgs: program.extraArgs || ""
 };
 
 // Disabled this rule so we can hoist the callback

--- a/src/cli.test.js
+++ b/src/cli.test.js
@@ -69,7 +69,6 @@ async function getCliInstallCommand(extraArgs) {
       }
       // The command will be the last non-whitespace line written to
       // stdout by the cli during a dry run
-
       const lines = fullstdout
         .join("")
         .split(/\r?\n/g)

--- a/src/cli.test.js
+++ b/src/cli.test.js
@@ -57,11 +57,11 @@ async function getCliInstallCommand(extraArgs) {
     const fullstderr = [];
     cli.stdout.on("data", data => {
       // not guaranteed to be line-by-line in fact these can be Buffers
-      fullstdout.push(data.toString());
+      fullstdout.push(String(data));
     });
     cli.stderr.on("data", data => {
       // not guaranteed to be line-by-line in fact these can be Buffers
-      fullstderr.push(data.toString());
+      fullstderr.push(String(data));
     });
     cli.on("close", code => {
       if (code !== 0) {

--- a/src/cli.test.js
+++ b/src/cli.test.js
@@ -54,11 +54,19 @@ async function getCliInstallCommand(extraArgs) {
     // non-whitespace line written to stdout
     const cli = spawnCli([...extraArgs, "--dry-run"]);
     const fullstdout = [];
+    const fullstderr = [];
     cli.stdout.on("data", data => {
       // not guaranteed to be line-by-line in fact these can be Buffers
-      fullstdout.push(data);
+      fullstdout.push(data.toString());
     });
-    cli.on("close", () => {
+    cli.stderr.on("data", data => {
+      // not guaranteed to be line-by-line in fact these can be Buffers
+      fullstderr.push(data.toString());
+    });
+    cli.on("close", code => {
+      if (code !== 0) {
+        reject(new Error(`Unsuccessful exit code. ${fullstderr}`));
+      }
       // The command will be the last non-whitespace line written to
       // stdout by the cli during a dry run
 

--- a/src/cli.test.js
+++ b/src/cli.test.js
@@ -130,7 +130,7 @@ test("adds explicit `--save-dev` flag when using `-D, -d, --dev` with NPM", asyn
       flags.map(flag => getCliInstallCommand(["eslint-config-airbnb", flag]))
     );
     commands.forEach((command, i) =>
-      t.equal(/ --save-dev /.test(command), true, `flag: \`${flags[i]}\``)
+      t.equal(/ --save-dev\b/.test(command), true, `flag: \`${flags[i]}\``)
     );
   } catch (err) {
     t.fail(err);

--- a/src/install-peerdeps.js
+++ b/src/install-peerdeps.js
@@ -180,6 +180,7 @@ const getPackageString = ({ name, version }) => {
  * @param {string} options.packageName - the name of the package for which to install peer dependencies
  * @param {string} options.version - the version of the package
  * @param {string} options.packageManager - the package manager to use (Yarn or npm)
+ * @param {string} options.noRegistry - Disable going to a remote registry to find a list of peers. Use local node_modules instead
  * @param {string} options.registry - the URI of the registry to install from
  * @param {string} options.dev - whether to install the dependencies as devDependencies
  * @param {boolean} options.onlyPeers - whether to install the package itself or only its peers
@@ -193,6 +194,7 @@ function installPeerDeps(
     packageName,
     version,
     packageManager,
+    noRegistry,
     registry,
     dev,
     global,
@@ -205,7 +207,7 @@ function installPeerDeps(
   },
   cb
 ) {
-  getPackageJson({ packageName, noRegistry:onlyPeers, registry, auth, proxy, version })
+  getPackageJson({ packageName, noRegistry, registry, auth, proxy, version })
     // Catch before .then because the .then is so long
     .catch(err => cb(err))
     .then(data => {

--- a/src/install-peerdeps.js
+++ b/src/install-peerdeps.js
@@ -106,17 +106,20 @@ function spawnInstall(command, args) {
  * Gets the contents of the package.json for a package at a specific version
  * @param {Object} requestInfo - information needed to make the request for the data
  * @param {string} requestInfo.packageName - the name of the package
+ * @param {Boolean} requestInfo.noRegistry - Gets the package dependencies list from the local node_modules instead of remote registry
  * @param {string} requestInfo.registry - the URI of the registry on which the package is hosted
- * @param {Boolean} onlyPeers - true if only the peers have been requested to be installed. In this case, check for the package to already have been installed.
- * @param {string} version - the version (or version tag) to attempt to install. Ignored if an installed version of the package is found in node_modules.
+ * @param {string} requestInfo.version - the version (or version tag) to attempt to install. Ignored if an installed version of the package is found in node_modules.
  * @returns {Promise<Object>} - a Promise which resolves to the JSON response from the registry
  */
-function getPackageJson(
-  { packageName, registry, auth, proxy },
-  onlyPeers,
+function getPackageJson({
+  packageName,
+  noRegistry,
+  registry,
+  auth,
+  proxy,
   version
-) {
-  if (onlyPeers) {
+}) {
+  if (noRegistry) {
     if (fs.existsSync(`node_modules/${packageName}`)) {
       return Promise.resolve(
         JSON.parse(
@@ -202,7 +205,7 @@ function installPeerDeps(
   },
   cb
 ) {
-  getPackageJson({ packageName, registry, auth, proxy }, onlyPeers, version)
+  getPackageJson({ packageName, noRegistry:onlyPeers, registry, auth, proxy, version })
     // Catch before .then because the .then is so long
     .catch(err => cb(err))
     .then(data => {

--- a/src/install-peerdeps.test.js
+++ b/src/install-peerdeps.test.js
@@ -6,24 +6,9 @@ test("gets the package data from the registry correctly", t => {
   t.plan(1);
   getPackageData({
     packageName: "eslint-config-airbnb",
-    registry: "https://registry.npmjs.org"
+    packageManager: "npm"
   }).then(packageData => {
     t.equal(packageData.name, "eslint-config-airbnb");
-    t.end();
-  }, t.fail);
-});
-
-test("gets the package data from a custom registry correctly", t => {
-  // Only one async operation will run
-  t.plan(1);
-  getPackageData({
-    packageName: "@nathanhleung/install-peerdeps-custom-registry-test",
-    registry: `https://${process.env.GITHUB_USERNAME}:${process.env.GITHUB_PACKAGE_INSTALL_TOKEN}@npm.pkg.github.com`
-  }).then(packageData => {
-    t.equal(
-      packageData.name,
-      "@nathanhleung/install-peerdeps-custom-registry-test"
-    );
     t.end();
   }, t.fail);
 });


### PR DESCRIPTION
feat: use package manager to find peerDependencies

* Fixes #73 
* Closes #72 
* Closes #84

Removes a bunch of custom logic and leverages the "info"
command that all package managers provide for getting package
details from a remote registry. By using the package tool, we can
delegate proxy configs, private registry paths, and auth tokens
to the package manager. This is especially valuable in networks
that require complex proxy configurations, or when packages
have peerDependencies that may be in multiple other private
than the singular one that was specified

BREAKING_CHANGE: removes `--registry` `--auth` and `--proxy` options

Use `.npmrc` or `.yarnrc` to mange private registry paths, auth tokens, and proxy configs

**This also fixes the failing pnpm build matrix, allowing the dependabot setup to resume normal operations**