### PR TITLE
fix: add .cmd to commands on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,7 @@
     "@babel/polyfill": "^7.7.0",
     "cli-color": "^2.0.0",
     "commander": "^4.0.1",
-    "https-proxy-agent": "^4.0.0",
     "promptly": "^3.0.3",
-    "request": "^2.83.0",
-    "request-promise-native": "^1.0.5",
     "semver": "^6.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR hopefully resolves #123. Here is what I think is going on:

1. Before PR #85, which constitutes the main set of changes in v3.0.0, `spawnCommand` (a thin `install-peerdeps`-specific wrapper around `child_process.spawn` to promisify it) was called only in the **install step** (the call was something like `spawnCommand("npm", ["install", "eslint-config-airbnb", ...restOfPeerdeps]`).
1. The changes in #85 introduced a **second call** to `spawnCommand`, to get package info directly from the package manager (through some code along the lines of `spawnCommand("npm", ["info", "eslint-config-airbnb"])`.
1. There was some special handling in the **install step code, outside of `spawnCommand`**, to preprocess the first argument to `spawnCommand` on Windows due to https://github.com/nodejs/node/issues/3675. Namely, the call on Windows would be changed to something like `spawnCommand("npm.cmd", ["install", "eslint-config-airbnb"])` (note the `.cmd` suffix added to the first argument).
1. However, this special first argument handling **was not copied** to the package info retrieval code in #85, which I think is what led to #123 and breakage in v3.0.0 being reported on Windows.
1. This PR moves the special first argument handling **inside** of `spawnCommand`, automatically adding the `.cmd` suffix if it's not already present if it detects the tool running on Windows, which hopefully fixes #123 and prevents a bug like this from happening again in the future.