### PR TITLE
Don't coerce version strings to semver, quote package names

### DIFF
--- a/src/install-peerdeps.js
+++ b/src/install-peerdeps.js
@@ -247,7 +247,8 @@ function installPeerDeps(
           // Remove -0
           return packageName.substr(0, packageName.length - 2);
         }
-        return packageName;
+        // Fix #64 -- add quotes
+        return `"${packageName}"`;
       }
       // If we have spaces in our args spawn()
       // cries foul so we'll split the packagesString

--- a/src/install-peerdeps.js
+++ b/src/install-peerdeps.js
@@ -154,12 +154,9 @@ const getPackageString = ({ name, version }) => {
   if (version.indexOf(" ") >= 0) {
     // Semver ranges can have a join of comparator sets
     // e.g. '^3.0.2 || ^4.0.0' or '>=1.2.7 <1.3.0'
-    // Take each version in the range and find the maxSatisfying
-    const rangeSplit = version
-      .split(" ")
-      .map(v => coerce(v))
-      .filter(v => valid(v));
-    const versionToInstall = maxSatisfying(rangeSplit, version);
+    // Take the last version in the range
+    const rangeSplit = version.split(" ");
+    const versionToInstall = rangeSplit[rangeSplit.length - 1];
 
     if (versionToInstall === null) {
       return name;


### PR DESCRIPTION
`install-peerdeps` uses the [`semver`](https://www.npmjs.com/package/semver) package to coerce peerdep versions specified in `package.json` to specific, "valid"/literal versions of the form `x.y.z` to generate the peer dependency install command. However, this coercion means that a version specified as `^7` in `peerDependencies` is coerced to `7.0.0`, which might not necessarily exist.

Instead, we should just use the version directly specified in `package.json`. Resolves #71.

Also started quoting package names to resolve #64

## Previous Behavior

```
$ npx install-peerdeps --dev @wordpress/eslint-plugin --dry-run

install-peerdeps v3.0.1
This command would have been run to install @wordpress/eslint-plugin@latest:
npm install @wordpress/eslint-plugin@8.0.1 eslint@7.0.0 --save-dev
```

## New Behavior

```
$ npx install-peerdeps --dev @wordpress/eslint-plugin --dry-run

install-peerdeps v3.0.1
This command would have been run to install @wordpress/eslint-plugin@latest:
npm install "@wordpress/eslint-plugin@8.0.1" "eslint@^7" --save-dev
```

@karlhorky could you test this branch?

@ljharb should this change be classified as a bugfix (bump semver patch version)? it changes prior behavior but should result in more flexibility rather than less (i.e. the install command will install `@^7` etc rather than `@7.0.0`)