### PR TITLE
refactor: replace `cli-color` with `picocolors`

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -49,7 +49,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm cache clean --force
-      - run: npm install -g pnpm@3 yarn@1
+      - run: npm install -f -g pnpm@3 yarn@1
       - run: npm run tests-only
 
   node:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -49,7 +49,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm cache clean --force
-      - run: npm install -f -g pnpm@3 yarn@1
+      - run: npm install -g pnpm@3 yarn@1
       - run: npm run tests-only
 
   node:

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
   "license": "MIT",
   "dependencies": {
     "@babel/polyfill": "^7.7.0",
-    "cli-color": "^2.0.0",
     "commander": "^4.0.1",
+    "picocolors": "^1.1.1",
     "promptly": "^3.0.3",
     "semver": "^6.3.0"
   },

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import "@babel/polyfill";
 
-import clc from "cli-color";
+import colors from "picocolors";
 import { Command } from "commander";
 import { confirm } from "promptly";
 
@@ -60,7 +60,7 @@ program
   .parse(process.argv);
 
 // Print program name and version (like what Yarn does)
-console.log(clc.bold(`${name} v${version}`));
+console.log(colors.bold(`${name} v${version}`));
 
 // Make sure we're installing at least one package
 if (program.args.length === 0) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-import clc from "cli-color";
+import colors from "picocolors";
 
 // Some constants so we get an undefined
 // error instead of a silent typo in case
@@ -8,5 +8,5 @@ export const yarn = "yarn";
 export const pnpm = "pnpm";
 
 // Create prefixes for error/success events
-export const errorText = clc.red.bold("ERR");
-export const successText = clc.green.bold("SUCCESS");
+export const errorText = colors.red(colors.bold("ERR"));
+export const successText = colors.green(colors.bold("SUCCESS"));


### PR DESCRIPTION
`cli-color` -> `es5-ext` detected as a virus

https://github.com/medikoo/es5-ext/issues/186