### PR TITLE
test: add no-registry test

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+    "arrowParens": "always"
+}

--- a/fixtures/no-registry/.gitignore
+++ b/fixtures/no-registry/.gitignore
@@ -1,0 +1,4 @@
+# This weird order is required because of the way Git recursively ignores
+# directories. We need to re-include the parent `node_modules` first.
+!/node_modules
+!/node_modules/dummy-local-package/package.json

--- a/fixtures/no-registry/node_modules/dummy-local-package/package.json
+++ b/fixtures/no-registry/node_modules/dummy-local-package/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "dummy-local-package",
+    "private": true,
+    "version": "1.0.0",
+    "peerDependencies": {
+        "dummy-peer-dependency": "^1.0.0"
+    }
+}

--- a/fixtures/no-registry/package.json
+++ b/fixtures/no-registry/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pnpm",
+  "name": "no-registry",
   "version": "1.0.0",
   "main": "index.js",
   "author": "nathanhleung",

--- a/fixtures/sandbox/package-clean.json
+++ b/fixtures/sandbox/package-clean.json
@@ -1,11 +1,5 @@
 {
   "name": "sandbox",
   "private": true,
-  "dependencies": {
-    "eslint": "5.3.0",
-    "eslint-config-airbnb": "17.1.0",
-    "eslint-plugin-import": "2.14.0",
-    "eslint-plugin-jsx-a11y": "6.1.1",
-    "eslint-plugin-react": "7.11.0"
-  }
+  "dependencies": {}
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -149,7 +149,7 @@ const options = {
   dryRun: program.dryRun,
   auth: program.auth,
   // Args after -- will be passed through
-  extraArgs: program.extraArgs || "",
+  extraArgs: program.extraArgs || ""
 };
 
 // Disabled this rule so we can hoist the callback

--- a/src/has-yarn.js
+++ b/src/has-yarn.js
@@ -1,5 +1,5 @@
 import fs from "fs";
 import path from "path";
 
-export default cwd =>
+export default (cwd) =>
   fs.existsSync(path.resolve(cwd || process.cwd(), "yarn.lock"));

--- a/src/has-yarn.test.js
+++ b/src/has-yarn.test.js
@@ -4,7 +4,7 @@ import hasYarn from "./has-yarn";
 
 const FIXTURES_DIR = path.join(__dirname, "..", "fixtures", "has-yarn");
 
-test("detects Yarn when a yarn.lock file is present", t => {
+test("detects Yarn when a yarn.lock file is present", (t) => {
   t.equal(hasYarn(path.join(FIXTURES_DIR, "yarn")), true);
   t.equal(hasYarn(path.join(FIXTURES_DIR, "noyarn")), false);
   t.end();

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -1,7 +1,7 @@
 import test from "tape";
 import { parsePackageString } from "./helpers";
 
-test("parses package strings correctly", t => {
+test("parses package strings correctly", (t) => {
   const installPeerdeps = parsePackageString("install-peerdeps@1.4.0");
   t.equal(installPeerdeps.packageName, "install-peerdeps");
   t.equal(installPeerdeps.packageVersion, "1.4.0");

--- a/src/install-peerdeps.js
+++ b/src/install-peerdeps.js
@@ -47,14 +47,14 @@ const spawnCommand = (command, args) => {
         shell: isWindows
       }
     );
-    cmdProcess.stdout.on("data", chunk => {
+    cmdProcess.stdout.on("data", (chunk) => {
       if (chunk instanceof Buffer) {
         stdout += chunk.toString("utf8");
       } else {
         stdout += chunk;
       }
     });
-    cmdProcess.stderr.on("data", chunk => {
+    cmdProcess.stderr.on("data", (chunk) => {
       if (chunk instanceof Buffer) {
         stderr += chunk.toString("utf8");
       } else {
@@ -62,7 +62,7 @@ const spawnCommand = (command, args) => {
       }
     });
     cmdProcess.on("error", reject);
-    cmdProcess.on("exit", code => {
+    cmdProcess.on("exit", (code) => {
       if (code === 0) {
         resolve(stdout);
       } else {
@@ -77,7 +77,7 @@ const spawnCommand = (command, args) => {
  * @returns {string} - The current Yarn version
  */
 function getYarnVersion() {
-  return spawnCommand("yarn", ["--version"]).then(it => it.trim());
+  return spawnCommand("yarn", ["--version"]).then((it) => it.trim());
 }
 
 /**
@@ -114,21 +114,21 @@ function findPackageVersion({ data, version }) {
 function getPackageData({ packageName, packageManager, version }) {
   const pkgString = version ? `${packageName}@${version}` : packageName;
   return getYarnVersion()
-    .then(yarnVersion => {
+    .then((yarnVersion) => {
       // Only return `yarnVersion` when we're using Yarn
       if (packageManager !== C.yarn) {
         return null;
       }
       return yarnVersion;
     })
-    .catch(err => {
+    .catch((err) => {
       if (packageManager === C.yarn) {
         throw err;
       }
       // If we're not trying to install with Yarn, we won't re-throw and instead will ignore the error and continue
       return null;
     })
-    .then(yarnVersion => {
+    .then((yarnVersion) => {
       // In Yarn versions >= 2, the `yarn info` command was replaced with `yarn npm info`
       const isUsingYarnGreaterThan1 =
         yarnVersion && !yarnVersion.startsWith("1.");
@@ -139,7 +139,7 @@ function getPackageData({ packageName, packageManager, version }) {
         "--json"
       ];
 
-      return spawnCommand(packageManager, args).then(response => {
+      return spawnCommand(packageManager, args).then((response) => {
         const parsed = JSON.parse(response);
 
         // Yarn 1 returns with an extra nested { data } that NPM doesn't
@@ -171,7 +171,7 @@ function getPackageJson({ packageName, noRegistry, packageManager, version }) {
 
   // Remote registry
   return getPackageData({ packageName, packageManager, version })
-    .then(data => {
+    .then((data) => {
       return Promise.resolve(
         findPackageVersion({
           data,
@@ -179,7 +179,7 @@ function getPackageJson({ packageName, noRegistry, packageManager, version }) {
         })
       );
     })
-    .then(version => {
+    .then((version) => {
       return getPackageData({
         packageName,
         packageManager,
@@ -243,8 +243,8 @@ function installPeerDeps(
 ) {
   getPackageJson({ packageName, noRegistry, packageManager, version })
     // Catch before .then because the .then is so long
-    .catch(err => cb(err))
-    .then(data => {
+    .catch((err) => cb(err))
+    .then((data) => {
       // Get peer dependencies for max satisfying version
       const peerDepsVersionMap = data.peerDependencies;
       if (typeof peerDepsVersionMap === "undefined") {
@@ -259,7 +259,7 @@ function installPeerDeps(
       // only its peers.
       let packagesString = onlyPeers ? "" : `${packageName}@${data.version}`;
 
-      const packageList = Object.keys(peerDepsVersionMap).map(name =>
+      const packageList = Object.keys(peerDepsVersionMap).map((name) =>
         getPackageString({
           name,
           version: peerDepsVersionMap[name]
@@ -333,7 +333,7 @@ function installPeerDeps(
       // There's a bug with Yarn 1.0 in which an empty arg
       // causes the install process to fail with a "malformed
       // response from the registry" error
-      args = args.filter(a => a !== "");
+      args = args.filter((a) => a !== "");
 
       //  Show user the command that's running
       const commandString = `${packageManager} ${args.join(" ")}\n`;
@@ -347,7 +347,7 @@ function installPeerDeps(
         console.log(commandString);
         spawnCommand(packageManager, args)
           .then(() => cb(null))
-          .catch(err => cb(err));
+          .catch((err) => cb(err));
       }
     });
 }

--- a/src/install-peerdeps.test.js
+++ b/src/install-peerdeps.test.js
@@ -1,13 +1,13 @@
 import test from "tape";
 import { getPackageData } from "./install-peerdeps";
 
-test("gets the package data from the registry correctly", t => {
+test("gets the package data from the registry correctly", (t) => {
   // Only one async operation will run
   t.plan(1);
   getPackageData({
     packageName: "eslint-config-airbnb",
     packageManager: "npm"
-  }).then(packageData => {
+  }).then((packageData) => {
     t.equal(packageData.name, "eslint-config-airbnb");
     t.end();
   }, t.fail);


### PR DESCRIPTION
* Adds test for `--no-registry` flag
* Adds explicit `arrowParens` Prettier rule ([this changed b/t Prettier 1 and 2](https://github.com/prettier/prettier/issues/6929); we're using Prettier 1)